### PR TITLE
Typo in the name of the function

### DIFF
--- a/1.8/elgg_social_login/vendors/hybridauth/index.php
+++ b/1.8/elgg_social_login/vendors/hybridauth/index.php
@@ -15,7 +15,7 @@ function exception_handler($e) {
 	throw new Exception( $e->getMessage(), $e->getCode() );
 }
 
-set_exception_handler( 'exception_handler ');
+set_exception_handler( 'exception_handler');
 
 
 require_once( "Hybrid/Auth.php" );


### PR DESCRIPTION
There is a typo in the name of the function that we use in the set_exception_handler